### PR TITLE
Bugfix: arreglo en las etiquetas de actividades recientes

### DIFF
--- a/frontend/src/components/Dashboard/RecentActivity.tsx
+++ b/frontend/src/components/Dashboard/RecentActivity.tsx
@@ -25,7 +25,7 @@ const RecentActivity = () => {
                 id: decision.id,
                 title: decision.title,
                 category: decision.category,
-                status: decision.evaluation ? 'evaluated' : 'progress',
+                status: decision.status,
             };
         }) || [];
     return (


### PR DESCRIPTION
No se mostraba los estilos de la etiqueta adecuada para las decisiones que ya había sido evaluadas.