### PR TITLE
Bugifx: renderizado automatico al editar la decision

### DIFF
--- a/frontend/src/components/Dashboard/DecisionsTable.tsx
+++ b/frontend/src/components/Dashboard/DecisionsTable.tsx
@@ -297,6 +297,7 @@ function DecisionsTable({
                         setSnackbarMessage(msg);
                         setSnackbarSuccess(success);
                         closeModal();
+                        if (onRefresh) onRefresh();
                     }}
                     isOpen={modal}
                     onClose={() => {

--- a/frontend/src/components/Decision/DecisionForm.tsx
+++ b/frontend/src/components/Decision/DecisionForm.tsx
@@ -131,7 +131,7 @@ const DecisionForm = ({ isOpen, onClose, decisionId, onMessage }: Props) => {
                 res = await axios.put(`http://localhost:5000/api/decision/${decisionId}`, data, {
                     withCredentials: true,
                 });
-                onMessage?.(res.data.message, true);
+                onMessage?.(res.data.message || 'Decisión actualizada', true);
             } else {
                 // creando una nueva
                 res = await axios.post('http://localhost:5000/api/decision', data, {


### PR DESCRIPTION
Faltaba pasar la función que hace que se recargue el componente para mostrar la decisión editada con los nuevos datos cuando se cierre el modal